### PR TITLE
Fix conditions for determining whether an event is included

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -5,7 +5,8 @@ const (
 	ScriptSubcommand  = "script"
 	ProfilingFileName = "perf.data"
 	ScriptFileName    = "perf.script"
-	CpuEvent          = "cpu-clock:pppH:"
+	CpuClockEvent     = "cpu-clock:"
+	CyclesEvent       = "cycles:"
 )
 
 const (

--- a/internal/resource/perf.go
+++ b/internal/resource/perf.go
@@ -96,7 +96,7 @@ func (p *PerfExecuter) GetEvent(ctx context.Context, path string) (*bytes.Buffer
 
 // Check if events are contained in the perf.data file.
 func (p *PerfExecuter) HasPerfEvent(ctx context.Context, buf *bytes.Buffer) bool {
-	return strings.Contains(buf.String(), constants.CpuEvent)
+	return strings.Contains(buf.String(), constants.CyclesEvent) || strings.Contains(buf.String(), constants.CpuClockEvent)
 }
 
 func (p *PerfExecuter) ExecScript(ctx context.Context, path, workDir string) (string, error) {


### PR DESCRIPTION
Until now, after executing perf record, necoperf checked whether the cpu-clock event was included in the perf.data file to confirm that the sample was acquired correctly.
However, when perf record was executed on the actual device, cycles events were recorded in the perf.data file instead of cpu-clock events, and necoperf could not correctly determine whether the sample was acquired.
To correct this bug, I changed the condition in the part that checks if the event is included.