### PR TITLE
Update Flatcar to 4593.0.0 (perf 6.14) and specify cycles event explicitly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,8 @@ jobs:
       - run: make -C e2e setup
       - run: make -C e2e start
       - run: make -C e2e test
+      - run: make -C e2e show-log
+        if: always()
   perf:
     name: Run perf on CI env
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ e2e:
 run-perf:
 	uname -r
 	docker run --name perf --rm --entrypoint perf ghcr.io/flatcar/flatcar-sdk-amd64:$(FLATCAR_VERSION) version
-	docker run --name perf --rm --entrypoint perf --privileged ghcr.io/flatcar/flatcar-sdk-amd64:$(FLATCAR_VERSION) stat sleep 1
-	docker run --name perf --rm --entrypoint perf --privileged -v $(PWD):/out ghcr.io/flatcar/flatcar-sdk-amd64:$(FLATCAR_VERSION) record -ag -F 99 --call-graph dwarf -o /out/perf.data sleep 1
+	docker run --name perf --rm --entrypoint perf --privileged ghcr.io/flatcar/flatcar-sdk-amd64:$(FLATCAR_VERSION) list hw sw
+	docker run --name perf --rm --entrypoint perf --privileged -v $(PWD):/out ghcr.io/flatcar/flatcar-sdk-amd64:$(FLATCAR_VERSION) record -v -e cycles -ag -F 99 --call-graph dwarf -o /out/perf.data sleep 1
 	docker run --name perf --rm --entrypoint perf --privileged -v $(PWD):/out ghcr.io/flatcar/flatcar-sdk-amd64:$(FLATCAR_VERSION) script -F event -i /out/perf.data | sort -u
 
 ##@ Tools

--- a/Makefile.versions
+++ b/Makefile.versions
@@ -1,10 +1,5 @@
 # ref to https://github.com/orgs/flatcar/packages/container/package/flatcar-sdk-amd64
-# In the container image of flatcar 4081.0.0,
-# the method for determining capabilities in perf (version 6.7) has changed.
-# As a result, we cannot obtain profiling with perf unless the value of kptr_restrict is set to 0.
-# The capability determination method has been improved in perf version 6.12.
-# Until the version of perf included in the flatcar image is upgraded to 6.12, we will keep the flatcar version at 3815.2.2(perf version 6.3).
-FLATCAR_VERSION := 3815.2.2
+FLATCAR_VERSION := 4593.0.0
 
 # envtest
 ENVTEST_VERSION := release-0.22

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -84,3 +84,7 @@ $(KUBECTL)-$(E2ETEST_K8S_VERSION):
 .PHONY: clean
 clean:
 	rm -rf $(BIN_DIR)
+
+.PHONY: show-log
+show-log:
+	$(KUBECTL) logs -n necoperf daemonset/necoperf-daemon

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -7,6 +7,7 @@ const (
 	ScriptFileName    = "perf.script"
 	CpuClockEvent     = "cpu-clock:"
 	CyclesEvent       = "cycles:"
+	TaskClockEvent    = "task-clock:"
 )
 
 const (

--- a/internal/resource/perf.go
+++ b/internal/resource/perf.go
@@ -61,6 +61,8 @@ func (p *PerfExecuter) ExecRecord(ctx context.Context, workDir string, pid int, 
 	t := timeout.Seconds()
 	perfArgs := []string{
 		constants.RecordSubcommand,
+		"-v",
+		"-e", "cycles",
 		"-ag",
 		"-F", "99",
 		"--call-graph", "dwarf",
@@ -96,7 +98,7 @@ func (p *PerfExecuter) GetEvent(ctx context.Context, path string) (*bytes.Buffer
 
 // Check if events are contained in the perf.data file.
 func (p *PerfExecuter) HasPerfEvent(ctx context.Context, buf *bytes.Buffer) bool {
-	return strings.Contains(buf.String(), constants.CyclesEvent) || strings.Contains(buf.String(), constants.CpuClockEvent)
+	return strings.Contains(buf.String(), constants.CyclesEvent) || strings.Contains(buf.String(), constants.CpuClockEvent) || strings.Contains(buf.String(), constants.TaskClockEvent)
 }
 
 func (p *PerfExecuter) ExecScript(ctx context.Context, path, workDir string) (string, error) {


### PR DESCRIPTION
  - Update Flatcar 3815.2.2 -> 4593.0.0 (perf 6.3 -> perf 6.14)

      The capability detection bug was fixed in perf 6.12. So the workaround is no longer needed.

  - Explicitly specify `-e cycles` option in `perf record`

      The new version of perf changed the default profiling event.
      In the CI environment, this causes perf to attempt to use a hardware counter that is not available, and causes tests to fail.
      To avoid this, specifying `-e cycles` explicitly restores stable behavior.

  - Handle task-clock as a valid event

      In the CI environment, the perf now falls back to `task-clock`. So updated the event check accordingly.

  - Some debugging improvements